### PR TITLE
refactor model construction

### DIFF
--- a/experiments.py
+++ b/experiments.py
@@ -17,7 +17,7 @@ from interp.circuit.causal_scrubbing.hypothesis import (
 )
 
 from main import run_experiment
-from model import clean_model, construct_circuit
+from model import construct_circuit
 
 class FixedSampler(CondSampler):
     pos: int
@@ -143,9 +143,8 @@ def make_experiments(make_corr) -> dict[str, tuple[Correspondence, dict[str, Opt
 
 
 def run(experiments, exp_name, samples, save, verbose):
-    loss, good_induction_candidate, tokenizer, toks_int_values = construct_circuit()
     options = experiments[exp_name][1] or {}
-    with_a1_ind_inputs = clean_model(loss, **options)
+    with_a1_ind_inputs, good_induction_candidate, tokenizer, toks_int_values = construct_circuit(**options)
 
     if exp_name in ["transpose-ind"]:
         with_a1_ind_inputs = with_a1_ind_inputs.update(


### PR DESCRIPTION
Merge clean_model and construct_circuit in model.py. This is useful because now we retain access to all the variables local to construct_circuit, and can use them for fancy updates in (what used to be) clean_model.

Also: pull load_model_and_data out of construct_circuit